### PR TITLE
Update statistics.html

### DIFF
--- a/web/templ/problem/statistics.html
+++ b/web/templ/problem/statistics.html
@@ -15,7 +15,7 @@
 				<tr>
 					<th class="kn-table-cell" scope="col">{{getText "position"}}</th>
 					<th class="kn-table-cell" scope="col">{{getText "name"}}</th>
-					<th class="kn-table-cell" scope="col">{{getText "memory"}}</th>
+					<th class="kn-table-cell" scope="col">{{getText "time"}}</th>
 				</tr>
 				</thead>
 				<tbody>
@@ -41,7 +41,7 @@
 				<tr>
 					<th class="kn-table-cell" scope="col">{{getText "position"}}</th>
 					<th class="kn-table-cell" scope="col">{{getText "name"}}</th>
-					<th class="kn-table-cell" scope="col">{{getText "time"}}</th>
+					<th class="kn-table-cell" scope="col">{{getText "memory"}}</th>
 				</tr>
 				</thead>
 				<tbody>


### PR DESCRIPTION
Prior to this commit the table header for the memory statistics displayed "Time" as the name for the third column and vice-versa for the time statistics. This commit fixes that.