### PR TITLE
Adding links to submissions in leaderboards

### DIFF
--- a/web/templ/problem/statistics.html
+++ b/web/templ/problem/statistics.html
@@ -26,7 +26,7 @@
 									href="/profile/{{.Name}}">{{.Name}}</a>{{else}}????{{end}}</td>
 						<td class="kn-table-cell">
                             {{if gt .MaxTime -1.0}}
-                                {{formatMs .MaxTime}}
+								<a href="/submissions/{{$sub.ID}}">{{formatMs .MaxTime}}</a>
                             {{else}}-{{end}}
 						</td>
 					</tr>
@@ -52,7 +52,7 @@
 									href="/profile/{{.Name}}">{{.Name}}</a>{{else}}????{{end}}</td>
 						<td class="kn-table-cell">
                             {{if gt .MaxMemory -1}}
-                                {{humanizeMaxSize .MaxMemory}}
+								<a href="/submissions/{{$sub.ID}}">{{humanizeMaxSize .MaxMemory}}</a>
                             {{else}}-{{end}}
 						</td>
 					</tr>
@@ -79,7 +79,7 @@
 										href="/profile/{{.Name}}">{{.Name}}</a>{{else}}????{{end}}</td>
 							<td class="kn-table-cell">
 	                            {{if gt .CodeSize 0}}
-	                                {{humanizeCodeSize .MaxMemory}}
+									<a href="/submissions/{{$sub.ID}}">{{humanizeCodeSize .MaxMemory}}</a>
 	                            {{else}}-{{end}}
 							</td>
 						</tr>


### PR DESCRIPTION
Currently, the leaderboards in the statistics tab do not display links to the submissions which achieved the best results. This commit address that.